### PR TITLE
End study after 3 weeks

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -52,7 +52,7 @@ const baseStudySetup = {
   ],
   // maximum time that the study should run, from the first run
   expire: {
-    days: 356,
+    days: 21,
   },
   allowEnroll: true,
 };


### PR DESCRIPTION
Pref-flips can be effectively disabled from normandy but addon shield studies can only disable themselves. Reduced from 365 to match specs in PHD.